### PR TITLE
Fixed Loading Spinner Bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,12 +84,8 @@
     </table>
 
     <div class="content">
-        <div id="loading" class="loading-overlay">
-            <div class="spinner"></div>
-        </div>
-
         <div id="output" class="output">
-
+            
         </div>
     </div> <!-- end of .content -->
 </div> <!-- end of .page -->

--- a/main.js
+++ b/main.js
@@ -165,7 +165,8 @@ function boyer_moore_horspool(haystack, needle) {
 
 
 function search(query) {
-    displayLoading(true);
+    display
+    (true);
     clearResults();
 
     var keyword = document.getElementById("chk-match-phrase").checked ? [query.trim()] : query.trim().split(" ");
@@ -338,6 +339,8 @@ function displayLoading(toggle) {
     if (menuHeight > "160px") {
         $(".content").css("top", menuHeight);
     }
+    
+    $("#loading").remove();
 
     if(toggle) {
         $(".content").after("<div id='loading' class='loading-overlay' style='height: 100%; opacity: 0; pointer-events: none;'><div class='spinner'></div></div>");

--- a/main.js
+++ b/main.js
@@ -340,6 +340,8 @@ function displayLoading(toggle) {
     }
 
     if(toggle) {
+        $(".content").after("<div id='loading' class='loading-overlay' style='height: 100%; opacity: 0; pointer-events: none;'><div class='spinner'></div></div>");
+        
         $("#loading").css("height", "100%").css("opacity", "1").css("pointer-events", "auto");
     }
     if(!toggle) {
@@ -350,6 +352,8 @@ function displayLoading(toggle) {
                 $("#loading").css("height", "0"); // Hack for IE10 pointer-events issue
             }
         });
+        
+        $("#loading").remove();
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -165,8 +165,7 @@ function boyer_moore_horspool(haystack, needle) {
 
 
 function search(query) {
-    display
-    (true);
+    displayLoading(true);
     clearResults();
 
     var keyword = document.getElementById("chk-match-phrase").checked ? [query.trim()] : query.trim().split(" ");
@@ -343,7 +342,7 @@ function displayLoading(toggle) {
     $("#loading").remove();
 
     if(toggle) {
-        $(".content").after("<div id='loading' class='loading-overlay' style='height: 100%; opacity: 0; pointer-events: none;'><div class='spinner'></div></div>");
+        $(".content").before("<div id='loading' class='loading-overlay' style='height: 100%; opacity: 1; pointer-events: auto;'><div class='spinner'></div></div>");
         
         $("#loading").css("height", "100%").css("opacity", "1").css("pointer-events", "auto");
     }

--- a/main.js
+++ b/main.js
@@ -342,7 +342,7 @@ function displayLoading(toggle) {
     $("#loading").remove();
 
     if(toggle) {
-        $(".content").before("<div id='loading' class='loading-overlay' style='height: 100%; opacity: 1; pointer-events: auto;'><div class='spinner'></div></div>");
+        $(".content").append("<div id='loading' class='loading-overlay' style='height: 100%; opacity: 1; pointer-events: auto;'><div class='spinner'></div></div>");
         
         $("#loading").css("height", "100%").css("opacity", "1").css("pointer-events", "auto");
     }

--- a/style.css
+++ b/style.css
@@ -120,6 +120,7 @@ table.head { table-layout: fixed; margin: auto; position: relative; z-index: 999
     opacity: 0;
     transition: opacity 0.3s;
     pointer-events: none;
+    z-index: 999;
 }
 
 .spinner {
@@ -130,6 +131,7 @@ table.head { table-layout: fixed; margin: auto; position: relative; z-index: 999
     border-top: 3px solid #000;
     border-radius: 12px;
     animation: spin 0.6s infinite linear;
+    z-index: 999;
 }
 
 @keyframes spin {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var version = 'v20170316.1'
+var version = 'v20170316.2'
 
 self.addEventListener('install', e => {
   e.waitUntil(

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var version = 'v20170316.3'
+var version = 'v20170316.4'
 
 self.addEventListener('install', e => {
   e.waitUntil(

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var version = 'v20170316.2'
+var version = 'v20170316.3'
 
 self.addEventListener('install', e => {
   e.waitUntil(

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var version = 'v20170314.3'
+var version = 'v20170316.1'
 
 self.addEventListener('install', e => {
   e.waitUntil(


### PR DESCRIPTION
Loading Spinner set to opacity 0 however was still drawing causing unneeded browser memory and cpu usage, resolved this by dynamically removing and adding to the DOM when required.